### PR TITLE
A couple minor fixes and Tweaks update

### DIFF
--- a/Cheap Checkout/Assets/CheapCheckoutModule/CheapCheckoutModule.cs
+++ b/Cheap Checkout/Assets/CheapCheckoutModule/CheapCheckoutModule.cs
@@ -28,6 +28,7 @@ public class CheapCheckoutModule : MonoBehaviour
 	string DOW = "";
 	bool waiting;
 	bool solved;
+	bool lightOn;
 	readonly List<List<string>> Receipt = new List<List<string>>();
 
 	static int idCounter = 1;
@@ -586,6 +587,7 @@ public class CheapCheckoutModule : MonoBehaviour
 						BombAudio.PlaySoundAtTransform("module_solved", transform);
 						StartCoroutine(Wait(3f, () =>
 						{
+							lightOn = true;
 							DebugMsg("Module solved!");
 							BombModule.HandlePass();
 
@@ -748,5 +750,6 @@ public class CheapCheckoutModule : MonoBehaviour
 		}
 
 		yield return ProcessTwitchCommand("submit " + (Paid - Total).ToString());
+		while (!lightOn) yield return true;
 	}
 }

--- a/Encrypted Equations/Assets/Encrypted Equations/EncryptedEquations.cs
+++ b/Encrypted Equations/Assets/Encrypted Equations/EncryptedEquations.cs
@@ -654,6 +654,7 @@ class EncryptedEquations : MonoBehaviour
 	public IEnumerator TwitchHandleForcedSolve()
 	{
 		yield return ProcessTwitchCommand("submit " + (CurrentEquation.ValueUndefined ? "" : CurrentEquation.Value.ToThousandths()));
+		while (isAnimating) yield return true;
 	}
 }
 

--- a/Minesweeper/Assets/MinesweeperModule/Scripts/MinesweeperModule.cs
+++ b/Minesweeper/Assets/MinesweeperModule/Scripts/MinesweeperModule.cs
@@ -22,6 +22,7 @@ public class MinesweeperModule : MonoBehaviour
 
 	public List<Sprite> Sprites;
 
+	bool lightOn;
 	bool loggedLegend;
 	static int idCounter = 1;
 	int moduleID;
@@ -399,6 +400,7 @@ public class MinesweeperModule : MonoBehaviour
 			yield return null;
 		}
 
+		lightOn = true;
 		Module.HandlePass();
 		UpdateSelectable();
 	}
@@ -1028,5 +1030,6 @@ public class MinesweeperModule : MonoBehaviour
 		}
 
 		StartCoroutine(SolveModule());
+		while (!lightOn) yield return true;
 	}
 }

--- a/Skewed Slots/Assets/SkewedSlotsModule/Scripts/SkewedModule.cs
+++ b/Skewed Slots/Assets/SkewedSlotsModule/Scripts/SkewedModule.cs
@@ -423,5 +423,6 @@ public class SkewedModule : MonoBehaviour
 	IEnumerator TwitchHandleForcedSolve()
 	{
 		yield return ProcessTwitchCommand(string.Concat(Solution[0], Solution[1], Solution[2]));
+		while (!solved) yield return true;
 	}
 }

--- a/Tweaks/TweaksAssembly/BombWrapper.cs
+++ b/Tweaks/TweaksAssembly/BombWrapper.cs
@@ -251,9 +251,8 @@ class BombWrapper : MonoBehaviour
 					case "primeEncryption":
 					case "memorableButtons":
 					case "babaIsWho":
-					case "colorfulDials":
-					case "scalarDials":
 					case "strikeSolve":
+					case "vexillology":
 						// This fixes the position of the status light
 						component.GetComponentInChildren<StatusLightParent>().transform.localPosition = new Vector3(0.075167f, 0.01986f, 0.076057f);
 						break;
@@ -270,7 +269,6 @@ class BombWrapper : MonoBehaviour
 				switch (bombModule.ModuleType)
 				{
 					case "babaIsWho":
-					case "needlesslyComplicatedButton":
 						component.GetComponent<Selectable>().Highlight.transform.localPosition = Vector3.zero;
 						break;
 				}


### PR DESCRIPTION
- Fixed TP autosolvers having the light turn on too early for Cheap Checkout, Encrypted Equations, Minesweeper, and Skewed Slots
- Removed mods from positioning fixes in Tweaks that no longer need it
- Added Vexillology to the list of mods in Tweaks that need a status light fix