### PR TITLE
Tweaks: Many module positioning fixes and new tweaks

### DIFF
--- a/Tweaks/TweaksAssembly/BombWrapper.cs
+++ b/Tweaks/TweaksAssembly/BombWrapper.cs
@@ -204,6 +204,7 @@ class BombWrapper : MonoBehaviour
 			{ "Color Decoding", bombComponent => new ColorDecodingTweak(bombComponent) },
 			{ "TurnTheKeyAdvanced", bombComponent => new TTKSTweak(bombComponent) },
 			{ "draw", bombComponent => new DrawTweak(bombComponent) },
+			{ "groceryStore", bombComponent => new GroceryStoreTweak(bombComponent) },
 
 			{ "Wires", bombComponent => new WiresLogging(bombComponent) },
 			{ "Keypad", bombComponent => new KeypadLogging(bombComponent) }
@@ -242,19 +243,19 @@ class BombWrapper : MonoBehaviour
 					case "CryptModule":
 					case "LEDEnc":
 						// This fixes the position of the module itself (but keeps the status light in its original location, which fixes it)
-						component.transform.Find("Model").transform.localPosition = new Vector3(0.004f, 0, 0);
+						component.transform.Find("Model").localPosition = new Vector3(0.004f, 0, 0);
 						break;
 					case "ColourFlash":
 					case "ColourFlashES":
 					case "ColourFlashPL":
 						// This fixes the position of the module itself (but keeps the status light in its original location)
-						component.transform.Find("ModuleBackground").transform.localPosition = Vector3.zero;
+						component.transform.Find("ModuleBackground").localPosition = Vector3.zero;
 						// This fixes the position of the status light
 						component.GetComponentInChildren<StatusLightParent>().transform.localPosition = new Vector3(0.075167f, 0.01986f, 0.076057f);
 						break;
 					case "Listening":
 						// This fixes the Y-coordinate of the position of the status light
-						component.transform.Find("StatusLight").transform.localPosition = new Vector3(-0.0761f, 0.01986f, 0.075f);
+						component.transform.Find("StatusLight").localPosition = new Vector3(-0.0761f, 0.01986f, 0.075f);
 						break;
 					case "TwoBits":
 					case "errorCodes":
@@ -266,21 +267,21 @@ class BombWrapper : MonoBehaviour
 						break;
 					case "matrix":
 						// This fixes the position of the module itself
-						for (int i = 0; i < component.transform.childCount; i++)
-							component.transform.GetChild(i).transform.localPosition -= new Vector3(0, 0.0053061005f, 0);
+						foreach (Transform child in component.transform)
+							child.localPosition -= new Vector3(0, 0.0053061005f, 0);
 						break;
 					case "memorableButtons":
 					case "strikeSolve":
 						// This fixes the position of the module itself
-						for (int i = 0; i < component.transform.childCount; i++)
-							component.transform.GetChild(i).transform.localPosition -= new Vector3(0, 0.0053061005f, 0);
+						foreach (Transform child in component.transform)
+							child.localPosition -= new Vector3(0, 0.0053061005f, 0);
 						// This fixes the position of the status light
 						component.GetComponentInChildren<StatusLightParent>().transform.localPosition = new Vector3(0.075167f, 0.01986f, 0.076057f);
 						break;
 					case "vexillology":
 						// This fixes the position of the module itself
-						for (int i = 0; i < component.transform.childCount; i++)
-							component.transform.GetChild(i).transform.localPosition -= new Vector3(0, 0.0053061005f, 0);
+						foreach (Transform child in component.transform)
+							child.localPosition -= new Vector3(0, 0.0053061005f, 0);
 						// This fixes the position of the status light
 						component.GetComponentInChildren<StatusLightParent>().transform.localPosition = new Vector3(0.075167f, 0.01986f, 0.076057f);
 						// This fixes the module selectable being pass through
@@ -301,17 +302,11 @@ class BombWrapper : MonoBehaviour
 						for (int i = 0; i < lights.Length; i++)
 							lights[i].range *= component.transform.lossyScale.x;
 						// This fixes the scale of the light components that could not be received using the first method
-						string[] lightSuffixes = { "Top", "1", "2", "3", "4" };
-						for (int i = 0; i < 5; i++)
-							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/yellowLights/yellowLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
-						for (int i = 0; i < 5; i++)
-							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/redLights/redLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
-						for (int i = 0; i < 5; i++)
-							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/greenLights/greenLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
-						for (int i = 0; i < 5; i++)
-							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/blueLights/blueLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
-						for (int i = 0; i < 5; i++)
-							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/pinkLights/pinkLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
+						foreach (var color in new[] { "yellow", "red", "green", "blue", "pink" })
+						{
+							foreach (var suffix in new[] { "Top", "1", "2", "3", "4" })
+								component.transform.Find($"hinge/wheelHolder/outerWheel/centre/centralOrb/{color}Lights/{color}Light{suffix}").GetComponent<Light>().range *= component.transform.lossyScale.x;
+						}
 						break;
 					case "sphere":
 						// This fixes the scale of the light components
@@ -351,12 +346,12 @@ class BombWrapper : MonoBehaviour
 						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
 						component.transform.Find("Model/ScreenBackground").gameObject.SetActive(false);
 						// This fixes the positions of the question and answer displays
-						component.transform.Find("Model/ScreenBackgroundQuestion").transform.localEulerAngles = new Vector3(-2.3f, -180, 0);
-						component.transform.Find("Model/ScreenBackgroundAnswer").transform.localEulerAngles = new Vector3(-2.3f, -180, 0);
-						component.transform.Find("Model/MathDisplay").transform.localPosition = new Vector3(-0.0533f, 0.0234f, 0.0616f);
-						component.transform.Find("Model/MathDisplay").transform.localEulerAngles = new Vector3(86, -720, 0);
-						component.transform.Find("Model/MathDisplayAnswer").transform.localPosition = new Vector3(0.0542f, 0.0234f, 0.0616f);
-						component.transform.Find("Model/MathDisplayAnswer").transform.localEulerAngles = new Vector3(86, -720, 0);
+						component.transform.Find("Model/ScreenBackgroundQuestion").localEulerAngles = new Vector3(-2.3f, -180, 0);
+						component.transform.Find("Model/ScreenBackgroundAnswer").localEulerAngles = new Vector3(-2.3f, -180, 0);
+						component.transform.Find("Model/MathDisplay").localPosition = new Vector3(-0.0533f, 0.0234f, 0.0616f);
+						component.transform.Find("Model/MathDisplay").localEulerAngles = new Vector3(86, -720, 0);
+						component.transform.Find("Model/MathDisplayAnswer").localPosition = new Vector3(0.0542f, 0.0234f, 0.0616f);
+						component.transform.Find("Model/MathDisplayAnswer").localEulerAngles = new Vector3(86, -720, 0);
 						break;
 					case "LightsOut":
 						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen

--- a/Tweaks/TweaksAssembly/BombWrapper.cs
+++ b/Tweaks/TweaksAssembly/BombWrapper.cs
@@ -203,6 +203,7 @@ class BombWrapper : MonoBehaviour
 			{ "WordScrambleModule", bombComponent => new WordScramblePatch(bombComponent) },
 			{ "Color Decoding", bombComponent => new ColorDecodingTweak(bombComponent) },
 			{ "TurnTheKeyAdvanced", bombComponent => new TTKSTweak(bombComponent) },
+			{ "draw", bombComponent => new DrawTweak(bombComponent) },
 
 			{ "Wires", bombComponent => new WiresLogging(bombComponent) },
 			{ "Keypad", bombComponent => new KeypadLogging(bombComponent) }
@@ -224,6 +225,7 @@ class BombWrapper : MonoBehaviour
 		foreach (BombComponent component in Bomb.BombComponents)
 		{
 			KMBombModule bombModule = component.GetComponent<KMBombModule>();
+			KMNeedyModule needyModule = component.GetComponent<KMNeedyModule>();
 			if (bombModule != null && (bombModule.ModuleType == "TurnTheKey" || Tweaks.settings.ModuleTweaks))
 			{
 				switch (bombModule.ModuleType)
@@ -340,56 +342,52 @@ class BombWrapper : MonoBehaviour
 						break;
 				}
 			}
-			else
+			else if (needyModule != null && Tweaks.settings.ModuleTweaks)
 			{
-				KMNeedyModule needyModule = component.GetComponent<KMNeedyModule>();
-				if (needyModule != null && Tweaks.settings.ModuleTweaks)
+				// Correct some mispositioned objects in some needy modules
+				switch (needyModule.ModuleType)
 				{
-					// Correct some mispositioned objects in some needy modules
-					switch (needyModule.ModuleType)
-					{
-						case "Needy Math":
-							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
-							component.transform.Find("Model/ScreenBackground").gameObject.SetActive(false);
-							// This fixes the positions of the question and answer displays
-							component.transform.Find("Model/ScreenBackgroundQuestion").transform.localEulerAngles = new Vector3(-2.3f, -180, 0);
-							component.transform.Find("Model/ScreenBackgroundAnswer").transform.localEulerAngles = new Vector3(-2.3f, -180, 0);
-							component.transform.Find("Model/MathDisplay").transform.localPosition = new Vector3(-0.0533f, 0.0234f, 0.0616f);
-							component.transform.Find("Model/MathDisplay").transform.localEulerAngles = new Vector3(86, -720, 0);
-							component.transform.Find("Model/MathDisplayAnswer").transform.localPosition = new Vector3(0.0542f, 0.0234f, 0.0616f);
-							component.transform.Find("Model/MathDisplayAnswer").transform.localEulerAngles = new Vector3(86, -720, 0);
-							break;
-						case "LightsOut":
-							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
-							component.transform.Find("Screen").gameObject.SetActive(false);
-							break;
-						case "Filibuster":
-							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
-							component.transform.Find("Model/Component_Needy_Background/Screen").gameObject.SetActive(false);
-							break;
-						case "needyMrsBob":
-							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
-							component.transform.Find("ancillary/Component_Needy_Background/Screen").gameObject.SetActive(false);
-							break;
-						case "draw":
-						case "rapidButtons":
-							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
-							component.transform.Find("Component_Needy_Background/Screen").gameObject.SetActive(false);
-							break;
-						case "simonSquawks":
-							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
-							component.transform.Find("Ancillary/Component_Needy_Background/Screen").gameObject.SetActive(false);
-							break;
-						case "triangleButtons":
-							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
-							component.transform.Find("Background/Screen").gameObject.SetActive(false);
-							break;
-					}
+					case "Needy Math":
+						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+						component.transform.Find("Model/ScreenBackground").gameObject.SetActive(false);
+						// This fixes the positions of the question and answer displays
+						component.transform.Find("Model/ScreenBackgroundQuestion").transform.localEulerAngles = new Vector3(-2.3f, -180, 0);
+						component.transform.Find("Model/ScreenBackgroundAnswer").transform.localEulerAngles = new Vector3(-2.3f, -180, 0);
+						component.transform.Find("Model/MathDisplay").transform.localPosition = new Vector3(-0.0533f, 0.0234f, 0.0616f);
+						component.transform.Find("Model/MathDisplay").transform.localEulerAngles = new Vector3(86, -720, 0);
+						component.transform.Find("Model/MathDisplayAnswer").transform.localPosition = new Vector3(0.0542f, 0.0234f, 0.0616f);
+						component.transform.Find("Model/MathDisplayAnswer").transform.localEulerAngles = new Vector3(86, -720, 0);
+						break;
+					case "LightsOut":
+						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+						component.transform.Find("Screen").gameObject.SetActive(false);
+						break;
+					case "Filibuster":
+						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+						component.transform.Find("Model/Component_Needy_Background/Screen").gameObject.SetActive(false);
+						break;
+					case "needyMrsBob":
+						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+						component.transform.Find("ancillary/Component_Needy_Background/Screen").gameObject.SetActive(false);
+						break;
+					case "draw":
+					case "rapidButtons":
+						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+						component.transform.Find("Component_Needy_Background/Screen").gameObject.SetActive(false);
+						break;
+					case "simonSquawks":
+						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+						component.transform.Find("Ancillary/Component_Needy_Background/Screen").gameObject.SetActive(false);
+						break;
+					case "triangleButtons":
+						// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+						component.transform.Find("Background/Screen").gameObject.SetActive(false);
+						break;
 				}
 			}
 
 			ModuleTweak moduleTweak = null;
-			string moduleType = bombModule != null ? bombModule.ModuleType : component.ComponentType.ToString();
+			string moduleType = bombModule != null ? bombModule.ModuleType : needyModule != null ? needyModule.ModuleType : component.ComponentType.ToString();
 			if (moduleTweaks.ContainsKey(moduleType) && (!moduleType.EqualsAny("WordScrambleModule", "TurnKeyAdvancedModule") || Tweaks.settings.ModuleTweaks))
 			{
 				moduleTweak = moduleTweaks[moduleType](component);

--- a/Tweaks/TweaksAssembly/BombWrapper.cs
+++ b/Tweaks/TweaksAssembly/BombWrapper.cs
@@ -234,13 +234,21 @@ class BombWrapper : MonoBehaviour
 						new TTKComponentSolver(component, bombModule, Tweaks.CurrentMode.Equals(Mode.Zen) ? Modes.initialTime : timerComponent.TimeRemaining);
 						break;
 
-					// Correct some mispositioned objects in older modules
+					// Correct some mispositioned objects in some regular modules
 					case "ForeignExchangeRates":
 					case "resistors":
 					case "CryptModule":
 					case "LEDEnc":
 						// This fixes the position of the module itself (but keeps the status light in its original location, which fixes it)
 						component.transform.Find("Model").transform.localPosition = new Vector3(0.004f, 0, 0);
+						break;
+					case "ColourFlash":
+					case "ColourFlashES":
+					case "ColourFlashPL":
+						// This fixes the position of the module itself (but keeps the status light in its original location)
+						component.transform.Find("ModuleBackground").transform.localPosition = Vector3.zero;
+						// This fixes the position of the status light
+						component.GetComponentInChildren<StatusLightParent>().transform.localPosition = new Vector3(0.075167f, 0.01986f, 0.076057f);
 						break;
 					case "Listening":
 						// This fixes the Y-coordinate of the position of the status light
@@ -249,19 +257,72 @@ class BombWrapper : MonoBehaviour
 					case "TwoBits":
 					case "errorCodes":
 					case "primeEncryption":
-					case "memorableButtons":
 					case "babaIsWho":
-					case "strikeSolve":
-					case "vexillology":
+					case "combinationLock":
 						// This fixes the position of the status light
 						component.GetComponentInChildren<StatusLightParent>().transform.localPosition = new Vector3(0.075167f, 0.01986f, 0.076057f);
+						break;
+					case "matrix":
+						// This fixes the position of the module itself
+						for (int i = 0; i < component.transform.childCount; i++)
+							component.transform.GetChild(i).transform.localPosition -= new Vector3(0, 0.0053061005f, 0);
+						break;
+					case "memorableButtons":
+					case "strikeSolve":
+						// This fixes the position of the module itself
+						for (int i = 0; i < component.transform.childCount; i++)
+							component.transform.GetChild(i).transform.localPosition -= new Vector3(0, 0.0053061005f, 0);
+						// This fixes the position of the status light
+						component.GetComponentInChildren<StatusLightParent>().transform.localPosition = new Vector3(0.075167f, 0.01986f, 0.076057f);
+						break;
+					case "vexillology":
+						// This fixes the position of the module itself
+						for (int i = 0; i < component.transform.childCount; i++)
+							component.transform.GetChild(i).transform.localPosition -= new Vector3(0, 0.0053061005f, 0);
+						// This fixes the position of the status light
+						component.GetComponentInChildren<StatusLightParent>().transform.localPosition = new Vector3(0.075167f, 0.01986f, 0.076057f);
+						// This fixes the module selectable being pass through
+						component.GetComponent<Selectable>().IsPassThrough = false;
 						break;
 					case "tWords":
 					case "moon":
 					case "sun":
+					case "jackOLantern":
+						// This fixes the scale of the light components
+						Light[] lights = component.GetComponentsInChildren<Light>();
+						for (int i = 0; i < lights.Length; i++)
+							lights[i].range *= component.transform.lossyScale.x;
+						break;
 					case "jewelVault":
 						// This fixes the scale of the light components
-						component.GetComponentInChildren<Light>().range *= component.transform.lossyScale.x;
+						lights = component.GetComponentsInChildren<Light>();
+						for (int i = 0; i < lights.Length; i++)
+							lights[i].range *= component.transform.lossyScale.x;
+						// This fixes the scale of the light components that could not be received using the first method
+						string[] lightSuffixes = { "Top", "1", "2", "3", "4" };
+						for (int i = 0; i < 5; i++)
+							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/yellowLights/yellowLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
+						for (int i = 0; i < 5; i++)
+							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/redLights/redLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
+						for (int i = 0; i < 5; i++)
+							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/greenLights/greenLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
+						for (int i = 0; i < 5; i++)
+							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/blueLights/blueLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
+						for (int i = 0; i < 5; i++)
+							component.transform.Find("hinge/wheelHolder/outerWheel/centre/centralOrb/pinkLights/pinkLight" + lightSuffixes[i]).GetComponent<Light>().range *= component.transform.lossyScale.x;
+						break;
+					case "sphere":
+						// This fixes the scale of the light components
+						lights = component.GetComponentsInChildren<Light>();
+						for (int i = 0; i < lights.Length; i++)
+							lights[i].range *= component.transform.lossyScale.x;
+						// This fixes the scale of the light components that could not be received using the first method
+						for (int i = 0; i < 11; i++)
+							component.transform.Find("stageLights/Light" + (i + 1) + "/Spotlight").GetComponent<Light>().range *= component.transform.lossyScale.x;
+						for (int i = 0; i < 19; i++)
+							component.transform.Find("interactionLights/Light" + (i + 1) + "/Spotlight").GetComponent<Light>().range *= component.transform.lossyScale.x;
+						component.transform.Find("interactionLights/Light10a/Spotlight").GetComponent<Light>().range *= component.transform.lossyScale.x;
+						component.transform.Find("interactionLights/Light10b/Spotlight").GetComponent<Light>().range *= component.transform.lossyScale.x;
 						break;
 				}
 
@@ -269,8 +330,61 @@ class BombWrapper : MonoBehaviour
 				switch (bombModule.ModuleType)
 				{
 					case "babaIsWho":
+					case "memorableButtons":
+					case "strikeSolve":
+					case "vexillology":
 						component.GetComponent<Selectable>().Highlight.transform.localPosition = Vector3.zero;
 						break;
+					case "matrix":
+						component.GetComponent<Selectable>().Highlight.transform.localPosition += new Vector3(0, 0.0053061005f, 0);
+						break;
+				}
+			}
+			else
+			{
+				KMNeedyModule needyModule = component.GetComponent<KMNeedyModule>();
+				if (needyModule != null && Tweaks.settings.ModuleTweaks)
+				{
+					// Correct some mispositioned objects in some needy modules
+					switch (needyModule.ModuleType)
+					{
+						case "Needy Math":
+							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+							component.transform.Find("Model/ScreenBackground").gameObject.SetActive(false);
+							// This fixes the positions of the question and answer displays
+							component.transform.Find("Model/ScreenBackgroundQuestion").transform.localEulerAngles = new Vector3(-2.3f, -180, 0);
+							component.transform.Find("Model/ScreenBackgroundAnswer").transform.localEulerAngles = new Vector3(-2.3f, -180, 0);
+							component.transform.Find("Model/MathDisplay").transform.localPosition = new Vector3(-0.0533f, 0.0234f, 0.0616f);
+							component.transform.Find("Model/MathDisplay").transform.localEulerAngles = new Vector3(86, -720, 0);
+							component.transform.Find("Model/MathDisplayAnswer").transform.localPosition = new Vector3(0.0542f, 0.0234f, 0.0616f);
+							component.transform.Find("Model/MathDisplayAnswer").transform.localEulerAngles = new Vector3(86, -720, 0);
+							break;
+						case "LightsOut":
+							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+							component.transform.Find("Screen").gameObject.SetActive(false);
+							break;
+						case "Filibuster":
+							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+							component.transform.Find("Model/Component_Needy_Background/Screen").gameObject.SetActive(false);
+							break;
+						case "needyMrsBob":
+							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+							component.transform.Find("ancillary/Component_Needy_Background/Screen").gameObject.SetActive(false);
+							break;
+						case "draw":
+						case "rapidButtons":
+							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+							component.transform.Find("Component_Needy_Background/Screen").gameObject.SetActive(false);
+							break;
+						case "simonSquawks":
+							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+							component.transform.Find("Ancillary/Component_Needy_Background/Screen").gameObject.SetActive(false);
+							break;
+						case "triangleButtons":
+							// This fixes z-fighting in the countdown screen by removing Unity's placeholder screen
+							component.transform.Find("Background/Screen").gameObject.SetActive(false);
+							break;
+					}
 				}
 			}
 

--- a/Tweaks/TweaksAssembly/Modules/DrawTweak.cs
+++ b/Tweaks/TweaksAssembly/Modules/DrawTweak.cs
@@ -1,0 +1,41 @@
+﻿using UnityEngine;
+
+class DrawTweak : ModuleTweak
+{
+	public DrawTweak(BombComponent bombComponent) : base(bombComponent, "DrawBehav")
+	{
+		// Set _isActive to false and force the material of the screen to be black when successfully doing the needy
+		bombComponent.GetComponent<KMNeedyModule>().OnPass += () => {
+			component.SetValue("_isActive", false);
+
+			Material passed = component.GetValue<Material>("screenMat");
+			passed.color = Color.black;
+			component.SetValue("screenMat", passed);
+			return false;
+		};
+
+		// Force the material of the screen to be black when the timer expires and stops the music if it is playing
+		bombComponent.GetComponent<KMNeedyModule>().OnTimerExpired += () => {
+			Material passed = component.GetValue<Material>("screenMat");
+			passed.color = Color.black;
+			component.SetValue("screenMat", passed);
+
+			foreach (DarkTonic.MasterAudio.SoundGroupVariation snd in DarkTonic.MasterAudio.MasterAudio.GetAllPlayingVariationsOfTransform(bombComponent.transform))
+			{
+				if (snd.SoundGroupName.Equals("draw_music"))
+					snd.Stop();
+			}
+		};
+
+		// Stops the music from playing when fire was pressed
+		bombComponent.GetComponent<KMSelectable>().Children[0].OnInteract += () =>
+		{
+			foreach (DarkTonic.MasterAudio.SoundGroupVariation snd in DarkTonic.MasterAudio.MasterAudio.GetAllPlayingVariationsOfTransform(bombComponent.transform))
+			{
+				if (snd.SoundGroupName.Equals("draw_music"))
+					snd.Stop();
+			}
+			return false;
+		};
+	}
+}

--- a/Tweaks/TweaksAssembly/Modules/GroceryStoreTweak.cs
+++ b/Tweaks/TweaksAssembly/Modules/GroceryStoreTweak.cs
@@ -1,0 +1,12 @@
+﻿class GroceryStoreTweak : ModuleTweak
+{
+	public GroceryStoreTweak(BombComponent bombComponent) : base(bombComponent, "GroceryStoreBehav")
+	{
+		// Remove the ability to press the buttons after the module is solved
+		bombComponent.OnPass += (_) => {
+			for (int i = 0; i < 2; i++)
+				bombComponent.GetComponent<KMSelectable>().Children[i].OnInteract = null;
+			return false;
+		};
+	}
+}


### PR DESCRIPTION
List of corrections:
- Colour Flash and its translated variants were slightly too far to the left on the x-axis
- Combination Lock's status light was floating
- The Matrix, Memorable Buttons, Vexillology and Strike/Solve were slightly too far up on the y-axis
- Vexillology had the module's selectable as Pass Through
- The light scale fixer only scaled down the first light it came in contact with and ignored the rest
- The Jack-O’-Lantern and The Sphere did not scale their lights properly
- Needy Math's question and answer displays were floating
- Needy Math, Filibuster, Needy Mrs. Bob, Draw, Rapid Buttons, Simon Squawks, and Triangle Buttons had z-fighting in their timer displays
- Draw had endless playing sound, visual glitches, and being able to play the mod when it was deactivated
- Grocery Store allowed for buttons to be pressed after it was solved

In many cases where I had to move a module around other items that were already correct got moved so they would have to get moved back, this is why you see some mods being added to the fix highlight section when they were fine before.