### PR TITLE
Repository DBMLIgnored field

### DIFF
--- a/Tweaks/TweaksAssembly/DemandBasedLoading.cs
+++ b/Tweaks/TweaksAssembly/DemandBasedLoading.cs
@@ -172,10 +172,12 @@ static class DemandBasedLoading
 			// Doesn't have a Steam ID.
 			// Isn't a module.
 			// Is on the user's exclude list.
+			// Is ignored
 			if (
 				module.SteamID == null ||
 				!(module.Type == "Regular" || module.Type == "Needy") ||
-				excluded.Contains(module.SteamID)
+				excluded.Contains(module.SteamID) ||
+				module.DBMLIgnored
 				)
 				continue;
 

--- a/Tweaks/TweaksAssembly/Network/Repository.cs
+++ b/Tweaks/TweaksAssembly/Network/Repository.cs
@@ -65,6 +65,7 @@ public static class Repository
 		public string Compatibility;
 		public Dictionary<string, object> TwitchPlays;
 		public string[] ObsoleteSteamIDs;
+		public bool DBMLIgnored;
 
 		public List<string> Ignore;
 	}


### PR DESCRIPTION
This allows modules to specify that DBML should ignore them.

Right now, the modules Black and White need to use this because a service is included which modifies bomb generation.