### PR TITLE
Fix Elevator of Doom causing exceptions

### DIFF
--- a/Tweaks/TweaksAssembly/BombStatus.cs
+++ b/Tweaks/TweaksAssembly/BombStatus.cs
@@ -53,7 +53,7 @@ class BombStatus : MonoBehaviour
 	{
 		if (currentBomb == null)
 		{
-			currentBomb = Tweaks.bombWrappers.Find(x => x.holdable.HoldState == FloatingHoldable.HoldStateEnum.Held);
+			currentBomb = Tweaks.bombWrappers.Find(x => (x.holdable != null && x.holdable.HoldState == FloatingHoldable.HoldStateEnum.Held) || x.holdable == null);
 			if (currentBomb != null)
 			{
 				UpdateSolves();

--- a/Tweaks/TweaksAssembly/BombWrapper.cs
+++ b/Tweaks/TweaksAssembly/BombWrapper.cs
@@ -28,7 +28,8 @@ class BombWrapper : MonoBehaviour
 		timerComponent = Bomb.GetTimer();
 		widgetManager = Bomb.WidgetManager;
 
-		holdable.OnLetGo += () => BombStatus.Instance.currentBomb = null;
+		if (holdable != null)
+			holdable.OnLetGo += () => BombStatus.Instance.currentBomb = null;
 
 		Color modeColor = ModeColors[Tweaks.CurrentMode];
 		BombStatus.Instance.TimerPrefab.color = modeColor;


### PR DESCRIPTION
Tweaks assumed that all bombs ran will have a FloatingHoldable component, which Elevator of Doom does not.

This fixes issue #55