### PR TITLE
Tweaks: (enhancement) Add min module count setting to Case Generator 

### DIFF
--- a/Tweaks/TweaksAssembly/Tweaks.cs
+++ b/Tweaks/TweaksAssembly/Tweaks.cs
@@ -918,7 +918,7 @@ class Tweaks : MonoBehaviour
 					new Dictionary<string, object> { { "Text", "Cases" }, { "Type", "Section" } },
 					new Dictionary<string, object> { { "Key", "BetterCasePicker" }, { "Text", "Better Case Picker" }, { "Description", "Chooses the smallest case that fits instead of a random one." } },
 					new Dictionary<string, object> { { "Key", "CaseGenerator" }, { "Text", "Case Generator" }, { "Description", "Generates a case to best fit the bomb which can be one of the colors defined by CaseColors." } },
-					new Dictionary<string, object> { { "Key", "CaseGeneratorMinModules" }, { "Text", "Case Generator Module Minimum" }, { "Description", "Disables generation of cases that hold less\nthan this many modules." } },
+					new Dictionary<string, object> { { "Key", "CaseGeneratorMinModules" }, { "Text", "Case Generator Module Minimum" }, { "Description", "Disables generation of cases that hold less\nthan this many modules. (Max. 24)" } },
 					new Dictionary<string, object> { { "Key", "CaseColors" }, { "Text", "Case Colors" }, { "Description", "Controls the color of the cases that are generated with Case Generator." } },
 
 					new Dictionary<string, object> { { "Text", "Tweaks" }, { "Type", "Section" } },

--- a/Tweaks/TweaksAssembly/Tweaks/BetterCasePicker.cs
+++ b/Tweaks/TweaksAssembly/Tweaks/BetterCasePicker.cs
@@ -109,6 +109,8 @@ class BetterCasePicker : Tweak
 		if (Tweaks.setupSettings.CaseGenerator)
 		{
 
+			int minModules = System.Math.Min(Tweaks.userSettings.CaseGeneratorMinModules, 24);
+
 			List<Vector2> caseSizes = new List<Vector2>();
 			for (int x = 1; x <= componentCount; x++)
 				for (int y = 1; y <= componentCount; y++)
@@ -117,7 +119,7 @@ class BetterCasePicker : Tweak
 
 			var caseSize = caseSizes
 				.Where(size => size.y / size.x >= 0.5f && size.x * size.y * (frontFaceOnly ? 1 : 2) >= componentCount)
-				.Where(size => size.x * size.y * 2 - 1 >= Tweaks.userSettings.CaseGeneratorMinModules)
+				.Where(size => size.x * size.y * 2 - 1 >= minModules)
 				.OrderBy(size => System.Math.Abs(size.x * size.y * (frontFaceOnly ? 1 : 2) - componentCount))
 				.ThenByDescending(size => size.y / size.x)
 				.FirstOrDefault();


### PR DESCRIPTION
With Reasonable Conclusion cases it is possible to disable smaller ones (e.g. 2x2 and 3x3) if the user prefers the vanilla bomb case or the Double Decker. This is not possible to do with the cases generated by Tweaks.

This PR adds a setting that discards cases under a user-defined threshold, allowing better case picker to choose non-generated cases for smaller bombs, if the user wants that.